### PR TITLE
Adjusted layout to eliminate horizontal scrolling and enhance margin settings

### DIFF
--- a/include/sdpDisplay.css
+++ b/include/sdpDisplay.css
@@ -10,6 +10,10 @@
     margin: 1px !important;
     padding: 5px 10px 5px 10px !important;
 }
+.container {
+    width: 100% !important;
+    max-width: none !important;
+}
 
 /******app CSS classes******/
 .section-label {
@@ -33,7 +37,7 @@
 }
 
 #description {
-    margin-left: 10px;
+    margin-right: 15px;
     margin-bottom: 5px;
     position: fixed;
     overflow-wrap: normal;

--- a/index.html
+++ b/index.html
@@ -11,19 +11,21 @@
     <script type="text/javascript" src="include/sdpDisplay.js"></script>
 </head>
 <body>
-    <div class="row">
-        <div class="col-sm-12">
-            <h1>Anatomy of a WebRTC SDP</h1>
-            <p>See the source post by Antón Román for more details.</p>
+    <div class="container">
+        <div class="row">
+            <div class="col-sm-12">
+                <h1>Anatomy of a WebRTC SDP</h1>
+                <p>See the source post by Antón Román for more details.</p>
+            </div>
         </div>
-    </div>
-    <div class="row">
-        <div class="col-sm-8">
-            <div id="lines" class="well"></div>
-        </div>
-        <div class="col-sm-4">
-            <div id="description">
-                Click/Hover your cursor at a code/line to view its description.
+        <div class="row">
+            <div class="col-sm-8">
+                <div id="lines" class="well"></div>
+            </div>
+            <div class="col-sm-4" >
+                <div id="description">
+                    Click/Hover your cursor at a code/line to view its description.
+                </div>
             </div>
         </div>
     </div>


### PR DESCRIPTION
Improvements:
- Redundant horizontal scrolling is removed
- Margins for `description` implemented to keep all elements inside the viewport 
 
Before (title is cut when content is scrolled to the right):
<img width="1512" alt="image" src="https://github.com/webrtcHacks/sdp-anatomy/assets/9114994/e340dac8-0d9b-4f25-9bda-27077c75d8a6">


After:
<img width="1512" alt="image" src="https://github.com/webrtcHacks/sdp-anatomy/assets/9114994/021d475c-128a-4378-8c32-6561b4c91514">

